### PR TITLE
Fix testing engine.

### DIFF
--- a/Text/PrettyPrint/Boxes.hs
+++ b/Text/PrettyPrint/Boxes.hs
@@ -182,7 +182,7 @@ text t = Box 1 (length t) (Text t)
 -- | Paste two boxes together horizontally, using a default (top)
 --   alignment.
 (<>) :: Box -> Box -> Box
-l <> r = hcat top [l,r]
+l <> r = hcat top [l,nullBox]
 
 -- | Paste two boxes together horizontally with a single intervening
 --   column of space, using a default (top) alignment.

--- a/Text/PrettyPrint/Boxes.hs
+++ b/Text/PrettyPrint/Boxes.hs
@@ -182,7 +182,7 @@ text t = Box 1 (length t) (Text t)
 -- | Paste two boxes together horizontally, using a default (top)
 --   alignment.
 (<>) :: Box -> Box -> Box
-l <> r = hcat top [l,nullBox]
+l <> r = hcat top [l,r]
 
 -- | Paste two boxes together horizontally with a single intervening
 --   column of space, using a default (top) alignment.

--- a/Text/PrettyPrint/Tests.hs
+++ b/Text/PrettyPrint/Tests.hs
@@ -63,9 +63,17 @@ prop_empty_left_id b  = nullBox <> b ==== b
 prop_empty_top_id b   = nullBox // b ==== b
 prop_empty_bot_id b   = b // nullBox ==== b
 
-main = do
-  quickCheck prop_render_text
-  quickCheck prop_empty_right_id
-  quickCheck prop_empty_left_id
-  quickCheck prop_empty_top_id
-  quickCheck prop_empty_bot_id
+main = quickCheckOrError
+    [ quickCheckResult prop_render_text
+    , quickCheckResult prop_empty_right_id
+    , quickCheckResult prop_empty_left_id
+    , quickCheckResult prop_empty_top_id
+    , quickCheckResult prop_empty_bot_id
+    ]
+
+quickCheckOrError :: [IO Result] -> IO ()
+quickCheckOrError xs = sequence xs >>= \results ->
+    let n = (length . filter (not . isSuccess)) results
+    in if n == 0 then return () else do
+            putStrLn $ "There are " ++ show n ++ " failing checks! Exiting with error."
+            exitFailure


### PR DESCRIPTION
So I was experimenting with this package and I noticed the test engine does not actually indicate the failing of any tests [_(it is a known problem)_][3] in its exit status, which I verified on Travis by sneaking a grave error. This patch ameliorates the omission.

* Before: [Here I am sneaking an error right under Travis's watchful nose.][1]
* After: [Now you see the alarms.][2]

[1]: https://travis-ci.org/kindaro/boxes/builds/570540343
[2]: https://travis-ci.org/kindaro/boxes/builds/570545453
[3]: https://stackoverflow.com/q/8976488