### PR TITLE
add a utility function for creating tables

### DIFF
--- a/Text/PrettyPrint/Boxes.hs
+++ b/Text/PrettyPrint/Boxes.hs
@@ -42,6 +42,8 @@ module Text.PrettyPrint.Boxes
 
     , punctuateH, punctuateV
 
+    , table
+
     -- * Alignment
 
 #ifdef TESTING
@@ -99,7 +101,7 @@ import Data.String (IsString(..))
 #endif
 
 import Control.Arrow ((***), first)
-import Data.List (foldl', intersperse)
+import Data.List (foldl', intersperse, transpose)
 
 import Data.List.Split (chunksOf)
 
@@ -240,6 +242,16 @@ punctuateH a p bs = hcat a (intersperse p (toList bs))
 -- | A vertical version of 'punctuateH'.
 punctuateV :: Foldable f => Alignment -> Box -> f Box -> Box
 punctuateV a p bs = vcat a (intersperse p (toList bs))
+
+-- | @table ah av bss@ lays out the boxes @bss@ in a table. Each element of
+-- @bss@ is treated as a row of the table. The height of each row and width of
+-- each column is computed from the sizes of the boxes they contain; the
+-- contents of the boxes are aligned horizontally according to @ah@ and
+-- vertically according to @av@.
+table :: (Foldable f, Foldable g) => Alignment -> Alignment -> f (g Box) -> Box
+table ah av bss_ = vcat ah (hcat av . zipWith (alignHoriz ah) ws <$> bss) where
+  ws = map (\bs -> maximum (0:map cols bs)) (transpose bss)
+  bss = toList <$> toList bss_
 
 --------------------------------------------------------------------------------
 --  Paragraph flowing  ---------------------------------------------------------


### PR DESCRIPTION
Occasionally I'd like to lay out a `[[Box]]` as a table. I can't just `hcat` each row, then `vcat` the results, because then the columns will not line up; and I can't just `vcat` each column, then `hcat` the results because then the rows will not line up. Of course, if you pre-compute either the widths of the columns or the heights of the rows, then you can pre-align the cells.

This commit introduces a simple utility function does this. It works by first computing the width of each column, pre-aligning all the cells horizontally according to these widths, then using `hcat` to coalesce the cells in a row and `vcat` to coalesce the rows.